### PR TITLE
Fixed grammar in Code of Conduct

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,61 +2,61 @@
 
 ## 1. Purpose
 
-A primary goal of Really Annoying Directory is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. We want to build a community that helps other people learn and make cool and fun things along the way. We're trying to build interesting/cool/useful together.
+A primary goal of the Really Annoying Directory is to be inclusive to the largest number of contributors, with the most varied and diverse backgrounds possible. We want to build a community that helps people learn to make cool and fun things along the way. We are trying to build interesting/cool/useful together.
 
-This code of conduct outlines our expectations for all those who participate in our community
+This code of conduct outlines our expectations for all those who participate in our community.
 
-We're all working towards the same goal, there's no reason to behave like we're not all on the same team.
+We are all working towards the same goal. There is no reason to behave like we are not all on the same team.
 
-## 3. Expected Behavior
+## 2. Expected Behavior
 
 The following behaviors are expected and requested of all community members:
 
 *   Participate in an authentic and active way. In doing so, you contribute to the health and longevity of this community.
 *   Attempt collaboration before conflict.
 *   Refrain from demeaning, discriminatory, or harassing behavior and speech.
-*   Behave as though we are a Team
+*   Behave as though we are a Team.
     
-    It is expected that you behave like it's a workplace and everyone here is your colleague regardless of experience level or personal feelings.
+    * It is expected that you behave like it is a workplace and everyone here is your colleague, regardless of experience level or personal feelings.
 
-*  Being Heavily Opinionated is Frowned Upon
-*   Laughing is Heavily Endorsed
+*  Being **Heavily Opinionated** is Frowned Upon
+*  Laughing is **Heavily** Endorsed
 
 
-## 4. Unacceptable Behavior
+## 3. Unacceptable Behavior
 
 The following behaviors are considered harassment and are unacceptable within our community:
 
 
-*   Doing or saying anything that is, sexist, racist, homophobic, transphobic, ableist, threats of violence  or otherwise discriminatory jokes and language makes you an Asshole. 
-*   Don't Be An Asshole
+*   Doing or saying anything that is: sexist, racist, homophobic, transphobic, ableist, threats of violence or otherwise discriminatory jokes and language, makes you an Asshole. 
+*   **Don't Be An Asshole**
 *   Posting or displaying sexually explicit or violent material.
 *   Deliberate intimidation, stalking or following (online or in person).
 *   Advocating for, or encouraging, any of the above behavior.
 
-## 5. Consequences of Unacceptable Behavior
+## 4. Consequences of Unacceptable Behavior
 
-Unacceptable behavior from any community member, including sponsors and those with decision-making authority, like me, will not be tolerated. 
+Unacceptable behavior from any community member, including sponsors and those with decision-making authority, will not be tolerated. 
 
-If anyone tells you to stop doing something that was mentioned above it's expected you'll do so.
+If anyone tells you to stop doing something that was mentioned above, it is expected you will do so.
 
-If for some reason I, or anyone else in charge of maintaining this repo/organization start behaving like this, I expect/would appreciate someone telling me / them to stop being an asshole. 
+If for some reason, anyone who is in charge of maintaining this repo/organization start behaving like this, we expect/would appreciate someone telling them to stop being an asshole. 
 
-## 6. Reporting Guidelines
+## 5. Reporting Guidelines
 
-If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. mention @moderator in the [discord](https://discord.gg/ZeMcrJQ)
+If you are subject to or witness unacceptable behavior, or have any other concerns, please notify a community organizer as soon as possible. Mention @moderator in the [discord](https://discord.gg/ZeMcrJQ).
 
 
-## 7. Addressing Grievances
+## 6. Addressing Grievances
 
-If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Learn Development Public with a concise description of your grievance. We'll hear you out and do our best to resolve the situation mention @moderator in the [discord](https://discord.gg/ZeMcrJQ)
+If you feel you have been falsely or unfairly accused of violating this Code of Conduct, you should notify Learn Development Public with a concise description of your grievance. We will hear you out and do our best to resolve the situation. Mention @moderator in the [discord](https://discord.gg/ZeMcrJQ).
 
-## 9. Contact info
+## 7. Contact info
 
-kopp020@gmail.com or [Discord](https://discord.gg/ZeMcrJQ)
+**Kevin [Tor020]** - kopp020@gmail.com or [Discord](https://discord.gg/ZeMcrJQ).
 
-## 10. License and attribution
+## 8. License and attribution
 
 This Code of Conduct is distributed under a [Creative Commons Attribution-ShareAlike license](http://creativecommons.org/licenses/by-sa/3.0/).
 
-Text Adapted [from](http://citizencodeofconduct.org/)
+Text Adapted [from](http://citizencodeofconduct.org/).


### PR DESCRIPTION
- fixed grammar mistakes in sentences and changed contractions to full words for better "Code of Conduct" language
- added bolding to important points
- changed "I" to "Us" so that the "Code of Conduct" sounds like a community built COC rather then just one admin