### PR TITLE
Fixed github-link-back, now work

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,6 @@
 </head>
 
 <body>
-    <a id="github-link-back" href="https://github.com/LearnDevelopmentPublic/ReallyAnnoyingDirectory">
-        View on Github <i class="fa fa-github"></i>
-    </a>
 
     <div class="style-select-wrap">
         <div class="style-select">Page Layout <span class="select-icon"><i class="fa fa-caret-down" aria-hidden="true"></i></span></div>
@@ -23,6 +20,11 @@
             <li class="style-list-item">Style Name</li>
         </ul>
     </div>
+
+    <a id="github-link-back" href="https://github.com/LearnDevelopmentPublic/ReallyAnnoyingDirectory">
+      View on Github <i class="fa fa-github"></i>
+    </a>
+
 
     <h1>Directory</h1>
 


### PR DESCRIPTION
The dropdown UI div was on top of the back button, so people can't go back on the github page